### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     }
   ],
   "require": {
+    "php": "^8.3",
     "guzzlehttp/guzzle": "^7.9"
   },
   "require-dev": {


### PR DESCRIPTION
Поюзал вашу библиотечку и минут 5 не могу понять почему падало с ошибкой синтаксиса
```
  syntax error, unexpected identifier "ASC", expecting "="

  at vendor/sazanof/novofon-api-v2/src/Builder/Sort.php:13
  ```
А потом понял что дело всё в том что юзается фича из нового PHP 8.3 такая как тайпхинты для констант